### PR TITLE
Fix KL computation

### DIFF
--- a/bayesian_torch/models/bayesian/resnet_flipout.py
+++ b/bayesian_torch/models/bayesian/resnet_flipout.py
@@ -132,13 +132,13 @@ class ResNet(nn.Module):
         out = F.relu(out)
         for l in self.layer1:
             out, kl = l(out)
-        kl_sum += kl
+            kl_sum += kl
         for l in self.layer2:
             out, kl = l(out)
-        kl_sum += kl
+            kl_sum += kl
         for l in self.layer3:
             out, kl = l(out)
-        kl_sum += kl
+            kl_sum += kl
 
         out = F.avg_pool2d(out, out.size()[3])
         out = out.view(out.size(0), -1)

--- a/bayesian_torch/models/bayesian/resnet_flipout_large.py
+++ b/bayesian_torch/models/bayesian/resnet_flipout_large.py
@@ -215,36 +215,20 @@ class ResNet(nn.Module):
         x = self.maxpool(x)
 
         for layer in self.layer1:
-            if 'Flipout' in str(layer):
-                x, kl = layer(x)
-                if kl is None:
-                    kl_sum += kl
-            else:
-                x = layer(x)
+            x, kl = layer(x)
+            kl_sum += kl
 
         for layer in self.layer2:
-            if 'Flipout' in str(layer):
-                x, kl = layer(x)
-                if kl is None:
-                    kl_sum += kl
-            else:
-                x = layer(x)
+            x, kl = layer(x)
+            kl_sum += kl
 
         for layer in self.layer3:
-            if 'Flipout' in str(layer):
-                x, kl = layer(x)
-                if kl is None:
-                    kl_sum += kl
-            else:
-                x = layer(x)
+            x, kl = layer(x)
+            kl_sum += kl
 
         for layer in self.layer4:
-            if 'Flipout' in str(layer):
-                x, kl = layer(x)
-                if kl is None:
-                    kl_sum += kl
-            else:
-                x = layer(x)
+            x, kl = layer(x)
+            kl_sum += kl
 
         x = self.avgpool(x)
         x = x.view(x.size(0), -1)

--- a/bayesian_torch/models/bayesian/resnet_variational.py
+++ b/bayesian_torch/models/bayesian/resnet_variational.py
@@ -152,13 +152,13 @@ class ResNet(nn.Module):
         out = F.relu(out)
         for l in self.layer1:
             out, kl = l(out)
-        kl_sum += kl
+            kl_sum += kl
         for l in self.layer2:
             out, kl = l(out)
-        kl_sum += kl
+            kl_sum += kl
         for l in self.layer3:
             out, kl = l(out)
-        kl_sum += kl
+            kl_sum += kl
 
         out = F.avg_pool2d(out, out.size()[3])
         out = out.view(out.size(0), -1)

--- a/bayesian_torch/models/bayesian/resnet_variational_large.py
+++ b/bayesian_torch/models/bayesian/resnet_variational_large.py
@@ -220,36 +220,20 @@ class ResNet(nn.Module):
         x = self.maxpool(x)
 
         for layer in self.layer1:
-            if 'Reparameterization' in str(layer):
-                x, kl = layer(x)
-                if kl is None:
-                    kl_sum += kl
-            else:
-                x = layer(x)
+            x, kl = layer(x)
+            kl_sum += kl
 
         for layer in self.layer2:
-            if 'Reparameterization' in str(layer):
-                x, kl = layer(x)
-                if kl is None:
-                    kl_sum += kl
-            else:
-                x = layer(x)
+            x, kl = layer(x)
+            kl_sum += kl
 
         for layer in self.layer3:
-            if 'Reparameterization' in str(layer):
-                x, kl = layer(x)
-                if kl is None:
-                    kl_sum += kl
-            else:
-                x = layer(x)
+            x, kl = layer(x)
+            kl_sum += kl
 
         for layer in self.layer4:
-            if 'Reparameterization' in str(layer):
-                x, kl = layer(x)
-                if kl is None:
-                    kl_sum += kl
-            else:
-                x = layer(x)
+            x, kl = layer(x)
+            kl_sum += kl
 
         x = self.avgpool(x)
         x = x.view(x.size(0), -1)


### PR DESCRIPTION
Hello,

I think there might be a few problems in your model definitions.

In particular:
- in `resnet_flipout.py` and `resnet_variational.py` you only sum the `kl` of the last `block` inside `self.layerN`
- in `resnet_flipout_large.py` and `resnet_variational_large.py` you check for `is None` while you probably want `is not None` or actually no check at all since it can't be `None` in any reasonable setting. Also the `str(layer)` check is odd since it contains a `BasicBlock` or `BottleNeck` object (you're looping over an `nn.Sequential` of `block`s). In fact in this code that string check is very likely superfluous (didn't test this, but I did include it in this PR as example)

I hope you can confirm and perhaps fix these issues, which will help me (and maybe others) in building on your nice codebase :)